### PR TITLE
refactor: change creating FolderFragment to Dagger Assisted Inject

### DIFF
--- a/srss/src/main/java/com/genius/srss/ui/folder/FolderFragment.kt
+++ b/srss/src/main/java/com/genius/srss/ui/folder/FolderFragment.kt
@@ -34,11 +34,11 @@ class FolderFragment : MvpAppCompatFragment(R.layout.fragment_folder), FolderVie
     BaseListAdapter.BaseListClickListener<BaseSubscriptionModel>, FolderTouchHelperCallback.TouchFolderListener {
 
     @Inject
-    lateinit var provider: Provider<FolderPresenter>
+    lateinit var provider: FolderPresenterFactory
 
     private val presenter: FolderPresenter by moxyPresenter {
         DIManager.appComponent.inject(this)
-        provider.get()
+        provider.create(arguments.folderId)
     }
 
     private val adapter: SubscriptionsListAdapter by lazy { SubscriptionsListAdapter() }
@@ -102,7 +102,7 @@ class FolderFragment : MvpAppCompatFragment(R.layout.fragment_folder), FolderVie
             consume(false)
         }
 
-        presenter.updateFolderFeed(arguments.folderId)
+        presenter.updateFolderFeed()
     }
 
     override fun onDestroyView() {

--- a/srss/src/main/java/com/genius/srss/ui/folder/FolderModels.kt
+++ b/srss/src/main/java/com/genius/srss/ui/folder/FolderModels.kt
@@ -3,7 +3,7 @@ package com.genius.srss.ui.folder
 import com.genius.srss.ui.subscriptions.BaseSubscriptionModel
 
 data class FolderStateModel(
-    val folderId: String? = null,
+    val folderId: String,
     val feedList: List<BaseSubscriptionModel> = listOf(),
     val title: String? = null
 )


### PR DESCRIPTION
For creation instances of objects with additional arguments other than those provided by Dependency Graph, since Dagger 2.31 you can use feature Assisted Inject. I think, creation of `FolderFragment` isthe nice place to implement this for demonstration

Documentation: https://dagger.dev/dev-guide/assisted-injection